### PR TITLE
Add a method to clear memory lru cache.

### DIFF
--- a/library/src/com/handlerexploit/prime/utils/ImageManager.java
+++ b/library/src/com/handlerexploit/prime/utils/ImageManager.java
@@ -274,6 +274,10 @@ public final class ImageManager {
         }
     }
 
+    public void clearMemoryLruCache() {
+        mLruCache.evictAll();
+    }
+
     private Bitmap getBitmapFromMemory(String key) {
         return mLruCache.get(key);
     }


### PR DESCRIPTION
This will be useful for apps which use Prime managing remote images for certain activity and would want to clear the cache while switching to another activity with large memory requirements.
