### PR TITLE
Introduce a cache into the ImageManager so it can reuse an old ByteArrayOutputStream

### DIFF
--- a/library/src/com/handlerexploit/prime/utils/ImageManager.java
+++ b/library/src/com/handlerexploit/prime/utils/ImageManager.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -118,6 +119,9 @@ public final class ImageManager {
     private ExecutorService mNetworkExecutorService = newConfiguredThreadPool();
 
     private ExecutorService mDiskExecutorService = Executors.newCachedThreadPool(new LowPriorityThreadFactory());
+    
+    private static ConcurrentLinkedQueue<ByteArrayOutputStream> mByteArrayOutputStreamCache =
+    		new ConcurrentLinkedQueue<ByteArrayOutputStream>();
 
     private ImageManager(Context context) {
         mCacheDirectory = getCacheDirectory(context).getAbsolutePath();
@@ -352,10 +356,16 @@ public final class ImageManager {
         ByteArrayOutputStream byteArrayOutputStream = null;
         try {
             inputStream = new URL(source).openConnection().getInputStream();
-            byteArrayOutputStream = new ByteArrayOutputStream();
+            byteArrayOutputStream = mByteArrayOutputStreamCache.poll();
+            if (byteArrayOutputStream == null) {
+            	byteArrayOutputStream = new ByteArrayOutputStream();
+            }
 
             IOUtils.copy(inputStream, byteArrayOutputStream);
-            return byteArrayOutputStream.toByteArray();
+            byte[] toReturn = byteArrayOutputStream.toByteArray();
+            byteArrayOutputStream.reset();
+            mByteArrayOutputStreamCache.add(byteArrayOutputStream);
+            return toReturn;
         } catch (MalformedURLException e) {
             Log.w(TAG, e);
         } catch (IOException e) {


### PR DESCRIPTION
Requesting multiple images from the network in a short period of time
can cause significant garbage collection as a new ByteArrayOutputStream
is created for each image requested from the network. Use an object
pool to keep around old ByteArrayOutputStreams for future use.

Important: this implementation introduces a memory leak becuase the
ByteArrayOutputStream cache is never emptied. I believe there are two
viable options:

  1.) Limit the size of the cache and accept the fact that the ImageManager
      has a memory overhead that will grow to some maximum.

  2.) Remove items from the cache if they are not used within a certain
      amount of time. Essentially a poor mans garbage collection.
